### PR TITLE
Add onion-service-client flag, enabling onion use.

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 lazy_static = "1.4"
 tokio = { version = "1", features = ["full"] }
-arti-client = { version = "0.22.0", features = ["static"] }
+arti-client = { version = "0.22.0", features = ["static", "onion-service-client"] }
 arti = { version = "1.2.7", features = ["experimental-api", "static"] }
 tor-rtcompat = { version = "0.22.0", features = ["static"] }
 tor-config = "0.22.0"


### PR DESCRIPTION
This could be related to or close any or all of these onion-related issues:

- https://github.com/Foundation-Devices/tor/issues/26
- https://github.com/Foundation-Devices/tor/issues/41
- https://github.com/Foundation-Devices/tor/issues/42

and we should follow up on them after enabling Onion service clients.