### PR TITLE
fix: use standard method to get random unused port

### DIFF
--- a/lib/tor.dart
+++ b/lib/tor.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
 import 'dart:isolate';
-import 'dart:math';
 
 import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart';
@@ -127,16 +126,15 @@ class Tor {
   }
 
   Future<int> _getRandomUnusedPort({List<int> excluded = const []}) async {
-    var random = Random.secure();
-    int potentialPort = 0;
+    int port = 0;
 
     retry:
-    while (potentialPort <= 0 || excluded.contains(potentialPort)) {
-      potentialPort = random.nextInt(65535);
+    while (port == 0 || excluded.contains(port)) {
       try {
-        var socket = await ServerSocket.bind("0.0.0.0", potentialPort);
+        var socket = await ServerSocket.bind("0.0.0.0", 0);
+        port = socket.port;
         socket.close();
-        return potentialPort;
+        return port;
       } catch (_) {
         continue retry;
       }


### PR DESCRIPTION
Current way does not ask the system but tries randomly to find a port. It has drawbacks such as:
- being less efficient that letting the system choose
- let the system potentially offer the same port until it is really used. Since only the port is returned and the socket is closed, a race condition could occur where another application bind to the port between calling this function to get a port and actually using it. 
Asking the system will ensure it will not suggest the same port again even if it's not used until all other ports have been given. Otherwise we would need to pass the opened socket instead of just the port to avoid the potential race condition.