### PR TITLE
Remove stale package attribute from AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,6 +4,5 @@ SPDX-FileCopyrightText: 2024 Foundation Devices Inc
 SPDX-License-Identifier: MIT
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.flutter_rust_bridge.rust_lib_backup">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Drop the leftover \`package=\"com.flutter_rust_bridge.rust_lib_backup\"\` attribute on \`<manifest>\` in \`android/src/main/AndroidManifest.xml\`. It was scaffolded off the \`backup\` package and never updated, and AGP 8+ rejects it.