### PR TITLE
Foundation-Devices/tor flutter_rust_bridge migration + Cypher Stack tor fixes/features

### DIFF
--- a/lib/socks_socket.dart
+++ b/lib/socks_socket.dart
@@ -93,7 +93,7 @@ class SOCKSSocket {
   StreamSubscription<List<int>>? get subscription => _subscription;
 
   /// Is SSL enabled?
-  final bool sslEnabled;
+  bool sslEnabled;
 
   /// Private constructor.
   SOCKSSocket._(this.proxyHost, this.proxyPort, this.sslEnabled);
@@ -216,6 +216,12 @@ class SOCKSSocket {
   /// Returns:
   ///   A Future that resolves to void.
   Future<void> connectTo(String domain, int port) async {
+    // Onion services provide their own end-to-end encryption, so disable the
+    // TLS upgrade when connecting to a .onion domain.
+    if (domain.endsWith('.onion')) {
+      sslEnabled = false;
+    }
+
     // Connect command.
     var request = [
       0x05, // SOCKS version.

--- a/lib/tor.dart
+++ b/lib/tor.dart
@@ -109,10 +109,14 @@ class Tor {
   }
 
   /// Start the Tor service.
-  Future<void> enable() async {
+  ///
+  /// If [dataDirPath] is provided, the Tor state and cache directories are
+  /// created underneath it. Otherwise the application support directory is
+  /// used.
+  Future<void> enable({String? dataDirPath}) async {
     _enabled = true;
     if (!started) {
-      await start();
+      await start(dataDirPath: dataDirPath);
     }
     broadcastState();
   }
@@ -143,20 +147,23 @@ class Tor {
   ///
   /// This will start the Tor service and establish a Tor circuit.
   ///
+  /// If [dataDirPath] is provided, the Tor state and cache directories are
+  /// created underneath it. Otherwise the application support directory is
+  /// used.
+  ///
   /// Throws an exception if the Tor service fails to start.
   ///
   /// Returns a Future that completes when the Tor service has started.
-  Future<void> start() async {
+  Future<void> start({String? dataDirPath}) async {
     broadcastState();
 
     await ensureRustLibInit();
 
     // Set the state and cache directories.
-    final Directory appSupportDir = await getApplicationSupportDirectory();
-    final stateDir =
-        await Directory('${appSupportDir.path}/tor_state').create();
-    final cacheDir =
-        await Directory('${appSupportDir.path}/tor_cache').create();
+    final String baseDirPath =
+        dataDirPath ?? (await getApplicationSupportDirectory()).path;
+    final stateDir = await Directory('$baseDirPath/tor_state').create();
+    final cacheDir = await Directory('$baseDirPath/tor_cache').create();
 
     // Generate a random port.
     int newPort = await _getRandomUnusedPort();

--- a/macos/tor.podspec
+++ b/macos/tor.podspec
@@ -41,5 +41,11 @@ Rust library providing Tor proxy functionality via arti.
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/librust_lib_tor.a',
+    # Strip the large static Rust library from release builds to reduce the
+    # shipped binary size.
+    'DEAD_CODE_STRIPPING' => 'YES',
+    'STRIP_INSTALLED_PRODUCT[config=Release][sdk=*][arch=*]' => 'YES',
+    'STRIP_STYLE[config=Release][sdk=*][arch=*]' => 'non-global',
+    'DEPLOYMENT_POSTPROCESSING[config=Release][sdk=*][arch=*]' => 'YES',
   }
 end


### PR DESCRIPTION
The frb-migration branch and this PR migrate to the upstream Foundation-Devices/tor, which has migrated from cargokit to flutter_rust_bridge, plus the fixes and features which now distinguish cypherstack/tor from the upstream 