### PR TITLE
chore(macos): strip Rust static library from release builds

### DIFF
--- a/macos/tor.podspec
+++ b/macos/tor.podspec
@@ -41,5 +41,11 @@ Rust library providing Tor proxy functionality via arti.
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/librust_lib_tor.a',
+    # Strip the large static Rust library from release builds to reduce the
+    # shipped binary size.
+    'DEAD_CODE_STRIPPING' => 'YES',
+    'STRIP_INSTALLED_PRODUCT[config=Release][sdk=*][arch=*]' => 'YES',
+    'STRIP_STYLE[config=Release][sdk=*][arch=*]' => 'non-global',
+    'DEPLOYMENT_POSTPROCESSING[config=Release][sdk=*][arch=*]' => 'YES',
   }
 end


### PR DESCRIPTION
Add DEAD_CODE_STRIPPING and Release-only STRIP settings to the macOS podspec so the large statically linked Rust library is stripped from release products, reducing the shipped binary size.

This comes from cypherstack/tor's divergences from your upstream Foundation-Devices/tor--we found this change useful and use it currently, but you can take it or leave it :)