### PR TITLE
fix: disable SSL for .onion domains in SOCKSSocket.connectTo

### DIFF
--- a/lib/socks_socket.dart
+++ b/lib/socks_socket.dart
@@ -93,7 +93,7 @@ class SOCKSSocket {
   StreamSubscription<List<int>>? get subscription => _subscription;
 
   /// Is SSL enabled?
-  final bool sslEnabled;
+  bool sslEnabled;
 
   /// Private constructor.
   SOCKSSocket._(this.proxyHost, this.proxyPort, this.sslEnabled);
@@ -216,6 +216,12 @@ class SOCKSSocket {
   /// Returns:
   ///   A Future that resolves to void.
   Future<void> connectTo(String domain, int port) async {
+    // Onion services provide their own end-to-end encryption, so disable the
+    // TLS upgrade when connecting to a .onion domain.
+    if (domain.endsWith('.onion')) {
+      sslEnabled = false;
+    }
+
     // Connect command.
     var request = [
       0x05, // SOCKS version.


### PR DESCRIPTION
Onion services are already end-to-end encrypted by the Tor protocol, so attempting a TLS handshake on top of a .onion connection is unnecessary and fails against services that do not present a certificate. Skip the SSL upgrade automatically when the target domain ends with .onion.

This comes from cypherstack/tor's divergences from your upstream Foundation-Devices/tor--we found this change useful and use it currently, but you can take it or leave it :)