### PR TITLE
docs: fix stale binding-generation instructions (ffigen -> flutter_rust_bridge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cargo install cargo-ndk
 
 ### Cargokit
 
-[Cargokit](https://github.com/irondash/cargokit) handles building, just `flutter run` it or run it in Android Studio or VS Code (untested).
+[Cargokit](https://github.com/irondash/cargokit) builds and bundles the native Rust library (in `rust/`) for each platform, just `flutter run` it or run it in Android Studio or VS Code (untested).
 
 To update Cargokit in the future, use:
 ```sh
@@ -32,7 +32,17 @@ git subtree pull --prefix cargokit https://github.com/irondash/cargokit.git main
 
 ## Development
 
-To (re)generate Dart bindings run `just generate`
+The Dart bindings in `lib/src/rust` are generated from the Rust API in `rust/` by [flutter_rust_bridge](https://github.com/fzyzcjy/flutter_rust_bridge).
+
+Install the codegen tool once, matching the `flutter_rust_bridge` version in `pubspec.yaml`:
+```sh
+cargo install flutter_rust_bridge_codegen --version 2.11.1
+```
+
+Then, after changing the Rust API, regenerate the bindings with:
+```sh
+flutter_rust_bridge_codegen generate
+```
 
 ## Example app
 


### PR DESCRIPTION
The README tells developers to regenerate Dart bindings with `just generate`, which runs `dart run ffigen`, which is the pre-FRB binding generator that is no longer a dependency, so the recipe fails. The project now generates bindings with flutter_rust_bridge; document the actual `flutter_rust_bridge_codegen generate` workflow instead.

Keep the Cargokit docs: cargokit still builds and bundles the native Rust library on every platform. Clarify that cargokit builds the library while flutter_rust_bridge only generates the bindings, since the two are easily confused.