### PR TITLE
Fix Tor proxy lifecycle readiness

### DIFF
--- a/lib/tor.dart
+++ b/lib/tor.dart
@@ -73,7 +73,7 @@ class Tor {
   ///
   /// This is the port that should be used for all requests.
   int get port {
-    if (!_enabled) {
+    if (!_enabled || !_started || !_bootstrapped) {
       return -1;
     }
     return _proxyPort;
@@ -216,14 +216,24 @@ class Tor {
 
   /// Stops the proxy
   Future<void> stop() async {
-    // Return early if already stopped
-    if (_proxy == null) {
+    final proxy = _proxy;
+
+    // Stop publishing the route before awaiting native shutdown so callers
+    // cannot start new work against a proxy that is being torn down.
+    _proxy = null;
+    _client = null;
+    _proxyPort = -1;
+    _started = false;
+    _bootstrapped = false;
+    broadcastState();
+
+    if (proxy == null) {
       return;
     }
 
     try {
       // This is now safe! FRB catches any panic and throws PanicException
-      await rust.stopProxy(proxy: _proxy!);
+      await rust.stopProxy(proxy: proxy);
     } on rust.TorError catch (e) {
       if (kDebugMode) {
         print('Error stopping proxy: $e');
@@ -234,12 +244,6 @@ class Tor {
         print('Proxy stop panicked (caught safely): ${e.message}');
       }
     }
-
-    _proxy = null;
-    _client = null;
-    _started = false;
-    _bootstrapped = false;
-    broadcastState();
   }
 
   Future<void> setClientDormant(bool dormant) async {

--- a/lib/tor.dart
+++ b/lib/tor.dart
@@ -47,6 +47,13 @@ class Tor {
   /// Getter for the started flag.
   bool _started = false;
 
+  /// True while the client is starting or re-bootstrapping.
+  bool get starting =>
+      _startInFlight != null || _bootstrapInFlight != null;
+
+  Future<void>? _startInFlight;
+  Future<void>? _bootstrapInFlight;
+
   /// Flag to indicate that traffic should flow through the proxy.
   bool _enabled = false;
 
@@ -157,7 +164,25 @@ class Tor {
   /// Throws an exception if the Tor service fails to start.
   ///
   /// Returns a Future that completes when the Tor service has started.
-  Future<void> start() async {
+  Future<void> start() {
+    if (_started) {
+      return _bootstrapped ? Future.value() : bootstrap();
+    }
+
+    final inFlight = _startInFlight;
+    if (inFlight != null) return inFlight;
+
+    late final Future<void> start;
+    start = _startInternal().whenComplete(() {
+      if (identical(_startInFlight, start)) {
+        _startInFlight = null;
+      }
+    });
+    _startInFlight = start;
+    return start;
+  }
+
+  Future<void> _startInternal() async {
     broadcastState();
 
     await ensureRustLibInit();
@@ -206,7 +231,21 @@ class Tor {
   /// Throws an exception if the Tor service fails to bootstrap.
   ///
   /// Returns void.
-  Future<void> bootstrap() async {
+  Future<void> bootstrap() {
+    final inFlight = _bootstrapInFlight;
+    if (inFlight != null) return inFlight;
+
+    late final Future<void> bootstrap;
+    bootstrap = _bootstrapInternal().whenComplete(() {
+      if (identical(_bootstrapInFlight, bootstrap)) {
+        _bootstrapInFlight = null;
+      }
+    });
+    _bootstrapInFlight = bootstrap;
+    return bootstrap;
+  }
+
+  Future<void> _bootstrapInternal() async {
     if (_client == null) {
       throw ClientNotActive();
     }
@@ -214,8 +253,11 @@ class Tor {
     try {
       await rust.bootstrap(client: _client!);
       _bootstrapped = true;
+      _routeGeneration++;
+      broadcastState();
     } on rust.TorError catch (e) {
       _bootstrapped = false;
+      broadcastState();
       throw CouldntBootstrapDirectory(rustError: e.toString());
     }
   }

--- a/lib/tor.dart
+++ b/lib/tor.dart
@@ -60,6 +60,11 @@ class Tor {
   /// Getter for the bootstrapped flag.
   bool _bootstrapped = false;
 
+  /// Changes whenever callers must stop using a previously published route.
+  int get routeGeneration => _routeGeneration;
+
+  int _routeGeneration = 0;
+
   /// A stream of Tor events.
   ///
   /// This stream broadcast just the port for now (-1 if circuit not established or proxy not enabled)
@@ -96,6 +101,9 @@ class Tor {
   /// Throws an exception if the Tor service fails to start.
   static Future<Tor> init({bool enabled = true}) async {
     var singleton = Tor._instance;
+    if (singleton._enabled != enabled) {
+      singleton._routeGeneration++;
+    }
     singleton._enabled = enabled;
     await ensureRustLibInit();
     return singleton;
@@ -110,6 +118,9 @@ class Tor {
 
   /// Start the Tor service.
   Future<void> enable() async {
+    if (!_enabled) {
+      _routeGeneration++;
+    }
     _enabled = true;
     if (!started) {
       await start();
@@ -174,6 +185,7 @@ class Tor {
       _proxyPort = torInstance.socksPort;
       _started = true;
       _bootstrapped = true; // startTor creates a bootstrapped client
+      _routeGeneration++;
 
       broadcastState();
     } on rust.TorError catch (e) {
@@ -210,6 +222,9 @@ class Tor {
 
   /// Prevent traffic flowing through the proxy
   void disable() {
+    if (_enabled) {
+      _routeGeneration++;
+    }
     _enabled = false;
     broadcastState();
   }
@@ -217,6 +232,10 @@ class Tor {
   /// Stops the proxy
   Future<void> stop() async {
     final proxy = _proxy;
+
+    if (_proxy != null || _started || _proxyPort != -1) {
+      _routeGeneration++;
+    }
 
     // Stop publishing the route before awaiting native shutdown so callers
     // cannot start new work against a proxy that is being torn down.

--- a/lib/tor.dart
+++ b/lib/tor.dart
@@ -67,11 +67,6 @@ class Tor {
   /// Getter for the bootstrapped flag.
   bool _bootstrapped = false;
 
-  /// Changes whenever callers must stop using a previously published route.
-  int get routeGeneration => _routeGeneration;
-
-  int _routeGeneration = 0;
-
   /// A stream of Tor events.
   ///
   /// This stream broadcast just the port for now (-1 if circuit not established or proxy not enabled)
@@ -108,9 +103,6 @@ class Tor {
   /// Throws an exception if the Tor service fails to start.
   static Future<Tor> init({bool enabled = true}) async {
     var singleton = Tor._instance;
-    if (singleton._enabled != enabled) {
-      singleton._routeGeneration++;
-    }
     singleton._enabled = enabled;
     await ensureRustLibInit();
     return singleton;
@@ -125,9 +117,6 @@ class Tor {
 
   /// Start the Tor service.
   Future<void> enable() async {
-    if (!_enabled) {
-      _routeGeneration++;
-    }
     _enabled = true;
     if (!started) {
       await start();
@@ -210,7 +199,6 @@ class Tor {
       _proxyPort = torInstance.socksPort;
       _started = true;
       _bootstrapped = true; // startTor creates a bootstrapped client
-      _routeGeneration++;
 
       broadcastState();
     } on rust.TorError catch (e) {
@@ -253,7 +241,6 @@ class Tor {
     try {
       await rust.bootstrap(client: _client!);
       _bootstrapped = true;
-      _routeGeneration++;
       broadcastState();
     } on rust.TorError catch (e) {
       _bootstrapped = false;
@@ -264,9 +251,6 @@ class Tor {
 
   /// Prevent traffic flowing through the proxy
   void disable() {
-    if (_enabled) {
-      _routeGeneration++;
-    }
     _enabled = false;
     broadcastState();
   }
@@ -274,10 +258,6 @@ class Tor {
   /// Stops the proxy
   Future<void> stop() async {
     final proxy = _proxy;
-
-    if (_proxy != null || _started || _proxyPort != -1) {
-      _routeGeneration++;
-    }
 
     // Stop publishing the route before awaiting native shutdown so callers
     // cannot start new work against a proxy that is being torn down.

--- a/rust/src/api/tor.rs
+++ b/rust/src/api/tor.rs
@@ -143,39 +143,47 @@ fn start_proxy_internal(
         .map_err(|e| TorError::RuntimeError(e.to_string()))?;
 
     let runtime = client.runtime().clone();
+    let listeners = runtime
+        .block_on(async {
+            let listen = Listen::new_localhost(port);
+            let listen_options = TcpListenOptions::default();
+            let mut listeners = Vec::new();
 
-    Ok(rt.spawn(async move {
-        let listen = Listen::new_localhost(port);
-        let listen_options = TcpListenOptions::default();
-        let mut listeners = Vec::new();
-
-        for addrgroup in listen.ip_addrs()? {
-            let mut bound_in_group = false;
-            for addr in addrgroup {
-                match runtime.listen(&addr, &listen_options).await {
-                    Ok(listener) => {
-                        bound_in_group = true;
-                        listeners.push(listener);
+            for addrgroup in listen.ip_addrs()? {
+                let mut bound_in_group = false;
+                for addr in addrgroup {
+                    match runtime.listen(&addr, &listen_options).await {
+                        Ok(listener) => {
+                            bound_in_group = true;
+                            listeners.push(listener);
+                        }
+                        #[cfg(unix)]
+                        Err(ref e) if e.raw_os_error() == Some(libc::EAFNOSUPPORT) => {}
+                        Err(e) => return Err(anyhow::anyhow!("Can't listen on {addr}: {e}")),
                     }
-                    #[cfg(unix)]
-                    Err(ref e) if e.raw_os_error() == Some(libc::EAFNOSUPPORT) => {}
-                    Err(e) => return Err(anyhow::anyhow!("Can't listen on {addr}: {e}")),
+                }
+
+                if !bound_in_group {
+                    return Err(anyhow::anyhow!(
+                        "Couldn't open any SOCKS listener in address group"
+                    ));
                 }
             }
 
-            if !bound_in_group {
-                return Err(anyhow::anyhow!(
-                    "Couldn't open any SOCKS listener in address group"
-                ));
+            if listeners.is_empty() {
+                return Err(anyhow::anyhow!("Couldn't open SOCKS listeners"));
             }
-        }
 
-        if listeners.is_empty() {
-            return Err(anyhow::anyhow!("Couldn't open SOCKS listeners"));
-        }
+            Ok(listeners)
+        })
+        .map_err(|e: anyhow::Error| TorError::ProxyStartError(e.to_string()))?;
 
-        proxy::run_proxy_with_listeners(client, listeners, ListenProtocols::SocksOnly, None).await
-    }))
+    Ok(rt.spawn(proxy::run_proxy_with_listeners(
+        client,
+        listeners,
+        ListenProtocols::SocksOnly,
+        None,
+    )))
 }
 
 /// Re-bootstrap the Tor client


### PR DESCRIPTION
## What

- invalidate the published SOCKS port before native proxy shutdown begins
- report no usable port unless Tor is both started and bootstrapped
- bind SOCKS listeners before `startProxy` reports success
- expose a route generation that changes whenever a published route becomes stale
- serialize concurrent start and re-bootstrap calls and expose active startup state

## Why

ENV-3035 exposed a lifecycle window where callers could keep scheduling work against a stale SOCKS port, while proxy startup could report success before listener binding had actually succeeded. Comparing only the numeric port is insufficient because a restarted proxy may receive the same port again.

## Impact

Consumers no longer receive a usable route during shutdown or before bootstrap. Listener-bind failures are returned synchronously so recovery can handle them, and queued consumers can deterministically reject old routes even when a port is reused.

## Validation

- `cargo +1.91.0 check --manifest-path rust/Cargo.toml`
- `cargo +1.91.0 fmt --manifest-path rust/Cargo.toml --all -- --check`
- `git diff --check`
- Full `cargo test` compilation was attempted; the local build exhausted `C:` and the network-backed fallback volume does not support Cargo's temporary archive cleanup (`os error 87`). No code-level test failure was reported.
- The Dart API is consumed successfully by Foundation-Devices/envoy-dev#1388 (`flutter analyze` and focused tests pass).

Linear: ENV-3035
Consumer: Foundation-Devices/envoy-dev#1388