### PR TITLE
docs: add security policy (SFT-7581)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Foundation Devices Inc.
+
+SPDX-License-Identifier: MIT
+-->
+
 # Security Policy
 
 ## Reporting a vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not open a public issue or discussion for a suspected security vulnerability.
+
+Report vulnerabilities privately through Foundation's responsible disclosure form:
+
+https://foundation.xyz/responsible-disclosure/
+
+For encrypted email, contact `security@foundation.xyz` using Foundation's security disclosure PGP key:
+
+https://foundation.xyz/pgp-email/
+
+Include, when possible:
+
+- the affected repository, product, version, release, or commit;
+- the vulnerability's security impact;
+- clear reproduction steps or a minimal proof of concept;
+- relevant logs, screenshots, or traces with secrets and personal data removed;
+- any suggested mitigation or fix.
+
+Do not include seed phrases, private keys, wallet passwords, API tokens, or customer data.
+
+## Disclosure process
+
+Please allow Foundation reasonable time to investigate and remediate the issue before public disclosure. Foundation's current scope, eligibility, disclosure requirements, and bounty terms are defined by the responsible disclosure policy linked above.
+
+## Supported versions
+
+Supported versions vary by project. Include the affected version or commit in your report. Foundation will confirm whether that version is currently supported and whether remediation will be applied to other maintained releases.


### PR DESCRIPTION
## Summary

- add a repository security policy
- direct private vulnerability reports to Foundation's responsible disclosure form and encrypted email contact

## Validation

- confirmed all contact links and the security email use the `foundation.xyz` domain
- documentation-only change

SFT-7581
